### PR TITLE
update ocsort with BYTE

### DIFF
--- a/tools/demo_track.py
+++ b/tools/demo_track.py
@@ -96,7 +96,7 @@ def image_demo(predictor, vis_folder, current_time, args):
     else:
         files = [args.path]
     files.sort()
-    tracker = OCSort(det_thresh=args.track_thresh, iou_threshold=args.iou_thresh)
+    tracker = OCSort(det_thresh=args.track_thresh, iou_threshold=args.iou_thresh, use_byte=args.use_byte)
     timer = Timer()
     results = []
 
@@ -161,7 +161,7 @@ def imageflow_demo(predictor, vis_folder, current_time, args):
     vid_writer = cv2.VideoWriter(
         save_path, cv2.VideoWriter_fourcc(*"mp4v"), fps, (int(width), int(height))
     )
-    tracker = OCSort(det_thresh=args.track_thresh, iou_threshold=args.iou_thresh)
+    tracker = OCSort(det_thresh=args.track_thresh, iou_threshold=args.iou_thresh, use_byte=args.use_byte)
     timer = Timer()
     frame_id = 0
     results = []

--- a/utils/args.py
+++ b/utils/args.py
@@ -54,6 +54,7 @@ def make_parser():
     parser.add_argument("--mot20", dest="mot20", default=False, action="store_true", help="test mot20.")
     parser.add_argument("--public", action="store_true", help="use public detection")
     parser.add_argument('--asso', default="iou", help="similarity function: iou/giou/diou/ciou/ctdis")
+    parser.add_argument("--use_byte", dest="use_byte", default=False, action="store_true", help="use byte in tracking.")
     
     # for kitti/bdd100k inference with public detections
     parser.add_argument('--raw_results_path', type=str, default="exps/permatrack_kitti_test/",

--- a/yolox/evaluators/mot_evaluator_dance.py
+++ b/yolox/evaluators/mot_evaluator_dance.py
@@ -217,7 +217,7 @@ class MOTEvaluator:
             model = model_trt
             
         tracker = OCSort(det_thresh = self.args.track_thresh, iou_threshold=self.args.iou_thresh,
-            asso_func=self.args.asso, delta_t=self.args.deltat, inertia=self.args.inertia)
+            asso_func=self.args.asso, delta_t=self.args.deltat, inertia=self.args.inertia, use_byte=self.args.use_byte)
         
         detections = dict()
 
@@ -240,7 +240,7 @@ class MOTEvaluator:
 
                 if frame_id == 1:
                     tracker = OCSort(det_thresh = self.args.track_thresh, iou_threshold=self.args.iou_thresh,
-                            asso_func=self.args.asso, delta_t=self.args.deltat, inertia=self.args.inertia)
+                            asso_func=self.args.asso, delta_t=self.args.deltat, inertia=self.args.inertia, use_byte=self.args.use_byte)
                     if len(results) != 0:
                         result_filename = os.path.join(result_folder, '{}.txt'.format(video_names[video_id - 1]))
                         write_results_no_score(result_filename, results)
@@ -350,6 +350,7 @@ class MOTEvaluator:
                 }  # COCO json format
                 data_list.append(pred_data)
         return data_list
+
 
 
     def evaluate_prediction(self, data_dict, statistics):


### PR DESCRIPTION
Update **OC-SORT** with **BYTE** in ByteTrack.

With `run_ocsort_dance_BYTE.py`, pretrained model and default settings, you can simply get **both higher MOTA and HOTA** than original OC-SORT and ByteTrack.

![image](https://user-images.githubusercontent.com/48764451/165333091-d89d99c1-40b7-4f45-8fd1-604a2210c15f.png)
