### PR TITLE
Fixed bugs introduced while converting from Python to C++

### DIFF
--- a/deploy/OCSort/cpp/src/KalmanFilter.cpp
+++ b/deploy/OCSort/cpp/src/KalmanFilter.cpp
@@ -1,4 +1,4 @@
-﻿#include "../include/KalmanFilter.hpp"
+#include "../include/KalmanFilter.hpp"
 #include <iostream>
 namespace ocsort {
     KalmanFilterNew::KalmanFilterNew() {};
@@ -26,7 +26,7 @@ namespace ocsort {
     };
     void KalmanFilterNew::predict() {
         x = F * x;
-        P = _alpha_sq * ((F * P), F.transpose()) + Q;
+        P = _alpha_sq * ((F * P) * F.transpose()) + Q;
         x_prior = x;
         P_prior = P;
     }
@@ -46,6 +46,7 @@ namespace ocsort {
         y = *z_ - H * x;
         auto PHT = P * H.transpose();
         S = H * PHT + R;
+        SI = S.inverse();
         K = PHT * SI;
         x = x + K * y;
         auto I_KH = I - K * H;


### PR DESCRIPTION
While testing OCSort C++ code base, I noticed that few variables were not matching. On digging deeper, I found couple of bugs in the C++ code after comparing to Python code.

1. A comma is given instead of multiplication operator resulting in the second operand `F.transpose()` being returned instead of `(F * P) * F.transpose()`:
[Python code](https://github.com/noahcao/OC_SORT/blob/master/trackers/ocsort_tracker/kalmanfilter.py#L1384):
`P = (alpha * alpha) * dot(dot(F, P), F.T) + Q`
Incorrect C++ code:
`P = _alpha_sq * ((F * P), F.transpose()) + Q;`
Correct C++ code:
`P = _alpha_sq * ((F * P) * F.transpose()) + Q;`

2. Added an inverse operation that was present in the [Python code](https://github.com/noahcao/OC_SORT/blob/master/trackers/ocsort_tracker/kalmanfilter.py#L506), but not in the C++ code.

Note: There is no change in line 1 and 156.